### PR TITLE
Update jvm common

### DIFF
--- a/conf/cloudControl-env.properties
+++ b/conf/cloudControl-env.properties
@@ -1,3 +1,3 @@
-JVM_BUILDPACK_COMMON_URL="https://packages.${DOMAIN}/jvm-buildpack-common-44.tar.gz"
+JVM_BUILDPACK_COMMON_URL="https://packages.${DOMAIN}/jvm-buildpack-common-20150202173416.tar.gz"
 MAVEN_SETTINGS_URL="https://packages.${DOMAIN}/settings.xml"
 MAVEN_URL="https://packages.${DOMAIN}/maven_3_1_with_cache_1.tar.gz"


### PR DESCRIPTION
I have decided to replace build number with timestamp and env prefix for non live builds (jvm-buildpack-common-20150202173306-dev.tar.gz). Previous build numbers where based on old jenkins build versioning.