### PR TITLE
Update jvm commons

### DIFF
--- a/conf/cloudControl-env.properties
+++ b/conf/cloudControl-env.properties
@@ -1,3 +1,3 @@
-JVM_BUILDPACK_COMMON_URL="https://packages.${DOMAIN}/jvm-buildpack-common-20150209142754.tar.gz"
+JVM_BUILDPACK_COMMON_URL="https://packages.${DOMAIN}/jvm-buildpack-common-20150220113111.tar.gz"
 MAVEN_SETTINGS_URL="https://packages.${DOMAIN}/settings.xml"
 MAVEN_URL="https://packages.${DOMAIN}/maven_3_1_with_cache_1.tar.gz"


### PR DESCRIPTION
buildpack-jvm-common diff:

cloudControl/buildpack-jvm-common@c468e2f Java 8 as a default one
cloudControl/buildpack-jvm-common@5c1851d Make request to latest versions silent
cloudControl/buildpack-jvm-common@1e4ed38 Install always latest jdk version